### PR TITLE
Use base command type as operation name

### DIFF
--- a/lib/mysql2/instrumentation.rb
+++ b/lib/mysql2/instrumentation.rb
@@ -37,7 +37,16 @@ module Mysql2
               'span.kind' => 'client',
             }
 
-            span = ::Mysql2::Instrumentation.tracer.start_span(sql, tags: tags)
+            operation_name = 'sql.query'
+            begin
+              candidate = sql.split(' ')[0]
+              unless candidate == nil or candidate.empty?
+                operation_name = candidate
+              end
+            rescue
+            end
+            span = ::Mysql2::Instrumentation.tracer.start_span(operation_name, tags: tags)
+
             query_original(sql, options)
           rescue => error
             span.set_tag("error", true)

--- a/spec/instrumentation_spec.rb
+++ b/spec/instrumentation_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Mysql2::Instrumentation do
       client.query(statement)
 
       expect(tracer.spans.count).to eq 1
+      expect(tracer.spans.last.operation_name).to eq 'SELECT'
 
       expected_tags = {
         'component' => 'mysql2',
@@ -63,7 +64,7 @@ RSpec.describe Mysql2::Instrumentation do
     end
 
     it 'sets the error tag and log' do
-      statement = "BAD_QUERY"
+      statement = 1234
       begin
         client.query(statement)
       rescue => e
@@ -79,6 +80,7 @@ RSpec.describe Mysql2::Instrumentation do
         'error' => true,
       }
       expect(tracer.spans.last.tags).to eq expected_tags
+      expect(tracer.spans.last.operation_name).to eq 'sql.query'
 
       expect(tracer.spans.last.logs.last[:key]).to eq('message')
       expect(tracer.spans.last.logs.last[:value]).to eq('error')


### PR DESCRIPTION
Span operation names are complete sql queries, which should be limited to their basic command type (this is what `db.statement` is for).